### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create, :edit, :update]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update, :destroy]
   before_action :set_item, only: [:show, :edit, :update, :destroy]
   before_action :authorize_user!, only: [:edit, :update]
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit, :update]
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
   before_action :authorize_user!, only: [:edit, :update]
 
   def index
@@ -34,7 +34,9 @@ class ItemsController < ApplicationController
     end
   end
 
-  def destory
+  def destroy
+    @item.destroy
+    redirect_to root_path
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -34,6 +34,9 @@ class ItemsController < ApplicationController
     end
   end
 
+  def destory
+  end
+
   private
 
   def set_item

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit, :update, :destroy]
   before_action :set_item, only: [:show, :edit, :update, :destroy]
-  before_action :authorize_user!, only: [:edit, :update]
+  before_action :authorize_user!, only: [:edit, :update, :destroy]
 
   def index
     @items = Item.order(created_at: :desc)

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
       <% if @item.user == current_user %>
         <%= link_to "商品の編集", edit_item_path, method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+        <%= link_to "削除", item_path(@item), data: {turbo_method: :delete}, class:"item-destroy" %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
       <% elsif @item.user != current_user %>
         <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,5 @@ Rails.application.routes.draw do
   get 'items/index'
   root to: 'items#index'
 
-  resources :items, only: [:index, :new, :create, :show, :edit, :update]
+  resources :items
 end


### PR DESCRIPTION
# What
・コントローラ側で、削除時にログインユーザーと商品の出品者が一致しない場合は、削除できないように認可チェックを追加。
・削除が完了した後、トップページにリダイレクトする処理を実装。

# Why
・商品を削除できるのは、その商品を出品したユーザーに限るべきであるため、出品者以外の不正な削除操作を防ぐ必要がある。
・認可チェックをコントローラーにも追加することで、ビューでのボタン制御だけでなく、セキュリティ面でも正確な認可を担保するため。
・削除完了後にトップページに遷移することで、ユーザーに削除が成功したことを視覚的に示すとともに、次の操作をスムーズに行えるようにするため。

# プルリクエストへ記載するgyazo
・ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/f74ad02ad08c74d0829a5487929113e7
※補足：DB上で「id:9」が削除されている画像
https://gyazo.com/56049175214bc4ca5237ba50968d5068